### PR TITLE
chore(composer): update composer dependencies for php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     ]
   },
   "require": {
-    "php": "^7.0",
-    "illuminate/view": "^7.12.0",
+    "php": "^7.0|^8.0",
+    "illuminate/view": "^7.30.6",
     "htmlburger/wpemerge": "~0.16.0"
   }
 }


### PR DESCRIPTION
Adding PHP 8.0 to composer requirement
(already in illuminate/view and htmlburger/wpemerge is >=5.5)

Updating to the lowest illuminate/view in 7 without this security advisories:
https://packagist.org/packages/illuminate/view/advisories?version=5732098

Not tested using a theme yet.